### PR TITLE
Got it working -- but we need better steps. Shit is cryptic

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,20 +147,12 @@ spec:
       securityContext: {}
       terminationGracePeriodSeconds: 30
 
-
-## Starting via Docker
-
-https://hub.docker.com/r/mathewfleisch/bashbot
-
-```bash
-# Create/copy .env file and config.json to wherever this next command runs:
-docker run -v ${PWD}/config.json:/bashbot/config.json -v ${PWD}/.env:/bashbot/.env -it mathewfleisch/bashbot:v1.1.0
 ```
-
 
 -------------------------------------------------------------------------
 
 ### .env file
+[sample-env-file](sample-env-file)
 
 ```bash
 export SLACK_TOKEN=<xoxb-xxxxxx-xxxxxx>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ Bashbot can be run as a go binary or as a container and requires an .env file fo
 
 Slack's permissions model has changed and the "[RTM](https://api.slack.com/rtm)" socket connection requires a "classic app" to be configured to get the correct type of token to run Bashbot. After logging into slack, visit [https://api.slack.com/apps?new_classic_app=1](https://api.slack.com/apps?new_classic_app=1) to set up a new "legacy bot user" and "Bot User OAuth Access Token" and save the `xoxb-xxxxxxxxx-xxxxxxx` as the environment variable `SLACK_TOKEN` in a `.env` file at bashbot's root.
 
+***Steps To Prove It's Working***
+
+- Once the Slack "Classic Bot" App is installed into your workspace, run it locally with the `entrypoint.sh` shell script.
+- If your `config.json` file is accessible according to your `.env` definitions AND your `SLACK_TOKEN` is actually associated with a "classic app", then the `start.sh` script should finish with:
+```
+CONNECTED; ACQUIRING TARGETING DATA
+```
+- Now you should be able to run a few commands in your slack channel ...
+- Create a new public channel in your slack called `#bot-test`
+- Invite the BashBot into your channel by typing `@BashBot`
+- Slackbot should respond with the message: `OK! I’ve invited @BashBot to this channel.`
+- Now type `bashbot help`
+- If all is configured correctly, you should see BashBot respond immediately with `Processing command...` and momentarily post a full list of commands that are defined in config.json
+
 ***Requirements***
 
 - jq
@@ -132,6 +146,15 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
+
+
+## Starting via Docker
+
+https://hub.docker.com/r/mathewfleisch/bashbot
+
+```bash
+# Create/copy .env file and config.json to wherever this next command runs:
+docker run -v ${PWD}/config.json:/bashbot/config.json -v ${PWD}/.env:/bashbot/.env -it mathewfleisch/bashbot:v1.1.0
 ```
 
 

--- a/sample-env-file
+++ b/sample-env-file
@@ -1,0 +1,6 @@
+export SLACK_TOKEN=
+export GIT_TOKEN=
+export github_org=
+export github_repo=
+export github_branch=
+export github_filename=


### PR DESCRIPTION
I was thrown a bit by your changes.  I think maybe a sample/empty .env file would be helpful.  Also more walkthru about setting up the Slack App.  I completely fucked that part up.  I was able to run it locally and on docker locally. It's pretty useful, but needs some polish.  Is there a way to detect that the Slack App is the new kind and won't work?  Instead of "bad token", those error messages can become better guides. 

Fun stuff.  