### PR TITLE
Regular expressions match valid params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ config.json
 tmp/*
 bin/*
 
-bashbot
+# bashbot


### PR DESCRIPTION
This minor change should be backwards compatible with all previous configuration but adds a new param type 'match' which allows a user's passed parameter to match by regular expression rather than by hardcoded list, or by derived list from a command. The limitations with this parameter type is that there can only be match type in each command, and it must be the last command. The reason for this is that a regular expression can include spaces, and therefore the words starting at the last param to the end of the passed values will be evaluated against the regex as a whole.

This change should satisfy this issue:
https://github.com/mathew-fleisch/bashbot/issues/52

And meet one prerequisite for this issue:
https://github.com/mathew-fleisch/bashbot/issues/60