### PR TITLE
Only run contianer builds after succesful go-binary build and git rel…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,7 @@ jobs:
           artifacts: "bin/*"
   build:
     name: Build and Push Bashbot Container
+    needs: [release]
     runs-on: ubuntu-latest
     steps:
       -
@@ -85,8 +86,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository_owner }}/bashbot/bashbot:latest
-            ghcr.io/${{ github.repository_owner }}/bashbot/bashbot:${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ github.repository_owner }}/bashbot:latest
+            ghcr.io/${{ github.repository_owner }}/bashbot:${{ env.RELEASE_VERSION }}
             mathewfleisch/bashbot:latest
             mathewfleisch/bashbot:${{ env.RELEASE_VERSION }}
           cache-from: type=registry,ref=mathewfleisch/bashbot:latest


### PR DESCRIPTION
…ease in release action